### PR TITLE
Feat/h0 protocol handlers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,8 +2,8 @@ services:
   broker:
     build: .
     ports:
-      - "8080:8080"   # http: /healthz, /metrics
-      - "7070:7070"   # tcp: frames
+      - "8080:8080" # http: /healthz, /metrics
+      - "7070:7070" # tcp: frames
     volumes:
       - ./data:/data
       - ./configs:/configs
@@ -23,3 +23,6 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+    volumes:
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning
+      - ./deploy/grafana/dashboards:/var/lib/grafana/dashboards

--- a/deploy/grafana/dashboards/cafelog-overview.json
+++ b/deploy/grafana/dashboards/cafelog-overview.json
@@ -1,0 +1,38 @@
+{
+    "title": "CafeLog Overview",
+    "schemaVersion": 39,
+    "version": 1,
+    "timezone": "browser",
+    "panels": [
+        {
+            "type": "timeseries",
+            "title": "Requests by type (rate)",
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "targets": [
+                {
+                    "expr": "sum by (type) (rate(cafelog_requests_total[1m]))"
+                }
+            ]
+        },
+        {
+            "type": "stat",
+            "title": "Active TCP connections",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 8
+            },
+            "targets": [
+                {
+                    "expr": "cafelog_tcp_connections_current"
+                }
+            ]
+        }
+    ]
+}

--- a/deploy/grafana/provisioning/dashboards/cafelog.yml
+++ b/deploy/grafana/provisioning/dashboards/cafelog.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: 'cafelog'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards
+      updateIntervalSeconds: 10

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -1,26 +1,502 @@
 package broker
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"log"
 	"net"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/Bay0312/cafelog/internal/proto"
 )
 
-type Broker struct {
-	// TODO: topics, partitions, offset store, metrics, cfg
+// ===========================
+// Metrics (registered once)
+// ===========================
+
+var (
+	metricsOnce sync.Once
+
+	requestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "cafelog",
+			Name:      "requests_total",
+			Help:      "Total protocol requests by type",
+		},
+		[]string{"type"},
+	)
+	errorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "cafelog",
+			Name:      "errors_total",
+			Help:      "Total broker logical errors by code",
+		},
+		[]string{"code"},
+	)
+	connectionsGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "cafelog",
+			Name:      "tcp_connections_current",
+			Help:      "Current number of active TCP connections",
+		},
+	)
+)
+
+func registerMetrics() {
+	metricsOnce.Do(func() {
+		prometheus.MustRegister(requestsTotal, errorsTotal, connectionsGauge)
+	})
 }
 
-func New() *Broker { return &Broker{} }
+func labelForType(t uint8) string {
+	switch t {
+	case proto.TypeCreateTopic:
+		return "CREATE_TOPIC"
+	case proto.TypeProduce:
+		return "PRODUCE"
+	case proto.TypeFetch:
+		return "FETCH"
+	case proto.TypeCommit:
+		return "COMMIT"
+	case proto.TypeHeartbeat:
+		return "HEARTBEAT"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ===========================
+// Logical error codes (spec)
+// ===========================
+
+const (
+	ErrInvalidRequest          = "INVALID_REQUEST"
+	ErrUnknownTopicOrPartition = "UNKNOWN_TOPIC_OR_PARTITION"
+	ErrOffsetOutOfRange        = "OFFSET_OUT_OF_RANGE"
+	ErrInternalIO              = "INTERNAL_IO_ERROR"
+)
+
+// ===========================
+// In-memory data structures
+// ===========================
+
+type Record struct {
+	Offset int64  `json:"offset"`
+	Key    []byte `json:"-"`
+	Value  []byte `json:"-"`
+	Ts     int64  `json:"ts"`
+}
+
+type Partition struct {
+	mu      sync.RWMutex
+	records []Record
+}
+
+func (p *Partition) appendRecs(in []Record) (base int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	base = int64(len(p.records))
+	for i := range in {
+		in[i].Offset = base + int64(i)
+	}
+	p.records = append(p.records, in...)
+	return base
+}
+
+func (p *Partition) fetch(start int64, max int) (out []Record, highWatermark int64) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	hw := int64(len(p.records))
+
+	// Semantics: -1 means latest (return empty, next offset == hw)
+	if start < 0 {
+		start = hw
+	}
+	if start > hw {
+		start = hw
+	}
+	if max <= 0 {
+		max = len(p.records)
+	}
+	end := start + int64(max)
+	if end > hw {
+		end = hw
+	}
+	cp := make([]Record, end-start)
+	copy(cp, p.records[start:end])
+	return cp, hw
+}
+
+type Topic struct {
+	Partitions []*Partition
+}
+
+type Broker struct {
+	mu      sync.RWMutex
+	topics  map[string]*Topic
+	offsets map[string]map[string]map[int]int64 // group -> topic -> partition -> nextOffset
+}
+
+// ===========================
+// Public constructor
+// ===========================
+
+func New() *Broker {
+	registerMetrics()
+	return &Broker{
+		topics:  make(map[string]*Topic),
+		offsets: make(map[string]map[string]map[int]int64),
+	}
+}
+
+// ===========================
+// Public TCP server
+// ===========================
 
 func (b *Broker) ServeTCP(l net.Listener) error {
 	log.Printf("TCP broker listening on %s", l.Addr())
 	for {
 		conn, err := l.Accept()
 		if err != nil {
+			// If listener is closed during shutdown, just return
+			if ne, ok := err.(net.Error); ok && !ne.Temporary() {
+				return err
+			}
 			return err
 		}
+		connectionsGauge.Inc()
 		go func(c net.Conn) {
-			defer c.Close()
-			// TODO: read frames and dispatch
+			defer func() {
+				connectionsGauge.Dec()
+				_ = c.Close()
+			}()
+			b.serveConn(c)
 		}(conn)
 	}
+}
+
+// ===========================
+// Connection loop
+// ===========================
+
+func (b *Broker) serveConn(c net.Conn) {
+	_ = c.SetDeadline(time.Time{}) // no deadline for now
+	for {
+		frame, err := proto.ReadFrame(c)
+		if err != nil {
+			// Normal connection close
+			if errors.Is(err, io.EOF) || isUseOfClosed(err) {
+				return
+			}
+			// Protocol/read error -> emit INVALID_REQUEST and close
+			writeError(c, frame.Type, ErrInvalidRequest, err)
+			return
+		}
+
+		requestsTotal.WithLabelValues(labelForType(frame.Type)).Inc()
+
+		switch frame.Type {
+		case proto.TypeCreateTopic:
+			var req CreateTopicRequest
+			if err := json.Unmarshal(frame.Payload, &req); err != nil {
+				writeError(c, frame.Type, ErrInvalidRequest, err)
+				continue
+			}
+			resp, berr := b.handleCreateTopic(req)
+			if berr != nil {
+				writeError(c, frame.Type, berr.Error, errors.New(berr.Error))
+				continue
+			}
+			writeJSON(c, frame.Type, resp)
+
+		case proto.TypeProduce:
+			var req ProduceRequest
+			if err := json.Unmarshal(frame.Payload, &req); err != nil {
+				writeError(c, frame.Type, ErrInvalidRequest, err)
+				continue
+			}
+			resp, berr := b.handleProduce(req)
+			if berr != nil {
+				writeError(c, frame.Type, berr.Error, errors.New(berr.Error))
+				continue
+			}
+			writeJSON(c, frame.Type, resp)
+
+		case proto.TypeFetch:
+			var req FetchRequest
+			if err := json.Unmarshal(frame.Payload, &req); err != nil {
+				writeError(c, frame.Type, ErrInvalidRequest, err)
+				continue
+			}
+			resp, berr := b.handleFetch(req)
+			if berr != nil {
+				writeError(c, frame.Type, berr.Error, errors.New(berr.Error))
+				continue
+			}
+			writeJSON(c, frame.Type, resp)
+
+		case proto.TypeCommit:
+			var req CommitRequest
+			if err := json.Unmarshal(frame.Payload, &req); err != nil {
+				writeError(c, frame.Type, ErrInvalidRequest, err)
+				continue
+			}
+			resp, berr := b.handleCommit(req)
+			if berr != nil {
+				writeError(c, frame.Type, berr.Error, errors.New(berr.Error))
+				continue
+			}
+			writeJSON(c, frame.Type, resp)
+
+		case proto.TypeHeartbeat:
+			// Simple echo OK (keeps the connection alive)
+			writeJSON(c, frame.Type, map[string]any{"ok": true})
+
+		default:
+			writeError(c, frame.Type, ErrInvalidRequest, fmt.Errorf("unknown type %d", frame.Type))
+		}
+	}
+}
+
+func isUseOfClosed(err error) bool {
+	// Best-effort detect closed conn without importing internal net errors
+	if err == nil {
+		return false
+	}
+	es := err.Error()
+	return es == "use of closed network connection"
+}
+
+// ===========================
+// Requests / Responses
+// ===========================
+
+type CreateTopicRequest struct {
+	Topic      string `json:"topic"`
+	Partitions int    `json:"partitions"`
+}
+type CreateTopicResponse struct {
+	OK bool `json:"ok"`
+}
+
+type RecordJSON struct {
+	Key   string `json:"key"`   // base64
+	Value string `json:"value"` // base64
+	Ts    int64  `json:"ts"`
+}
+
+type ProduceRequest struct {
+	Topic     string       `json:"topic"`
+	Partition int          `json:"partition"` // -1 => route by key hash
+	Records   []RecordJSON `json:"records"`
+}
+type ProduceResponse struct {
+	Topic         string `json:"topic"`
+	Partition     int    `json:"partition"`
+	BaseOffset    int64  `json:"baseOffset"`
+	NumRecords    int    `json:"numRecords"`
+	HighWatermark int64  `json:"highWatermark"`
+}
+
+type FetchRequest struct {
+	Topic     string `json:"topic"`
+	Partition int    `json:"partition"`
+	Offset    int64  `json:"offset"`    // -1 latest, 0 from-beginning
+	MaxBytes  int    `json:"maxBytes"`  // ignored in H0
+	MaxWaitMs int    `json:"maxWaitMs"` // ignored (no long-poll yet)
+}
+type FetchedRecord struct {
+	Offset int64  `json:"offset"`
+	Key    string `json:"key"`   // base64
+	Value  string `json:"value"` // base64
+	Ts     int64  `json:"ts"`
+}
+type FetchResponse struct {
+	Records       []FetchedRecord `json:"records"`
+	HighWatermark int64           `json:"highWatermark"`
+}
+
+type CommitRequest struct {
+	Topic     string `json:"topic"`
+	Partition int    `json:"partition"`
+	Group     string `json:"group"`
+	Offset    int64  `json:"offset"` // next to read
+}
+type CommitResponse struct {
+	OK bool `json:"ok"`
+}
+
+type ErrorResponse struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// ===========================
+// Handlers (in-memory)
+// ===========================
+
+type brokerErr struct{ Error string }
+
+func (b *Broker) handleCreateTopic(req CreateTopicRequest) (*CreateTopicResponse, *brokerErr) {
+	if req.Topic == "" || req.Partitions <= 0 {
+		return nil, &brokerErr{ErrInvalidRequest}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.topics[req.Topic]; ok {
+		// Idempotent create
+		return &CreateTopicResponse{OK: true}, nil
+	}
+	t := &Topic{Partitions: make([]*Partition, req.Partitions)}
+	for i := range t.Partitions {
+		t.Partitions[i] = &Partition{}
+	}
+	b.topics[req.Topic] = t
+	return &CreateTopicResponse{OK: true}, nil
+}
+
+func (b *Broker) handleProduce(req ProduceRequest) (*ProduceResponse, *brokerErr) {
+	if req.Topic == "" || len(req.Records) == 0 {
+		return nil, &brokerErr{ErrInvalidRequest}
+	}
+
+	topic, ok := b.getTopic(req.Topic)
+	if !ok {
+		return nil, &brokerErr{ErrUnknownTopicOrPartition}
+	}
+
+	part := req.Partition
+	if part < 0 {
+		// Route by key hash (first record key)
+		if len(req.Records) > 0 {
+			kb, _ := tryB64(req.Records[0].Key)
+			h := sha1.Sum(kb)
+			part = int(h[0]) % len(topic.Partitions)
+		} else {
+			part = 0
+		}
+	}
+	if part >= len(topic.Partitions) {
+		return nil, &brokerErr{ErrUnknownTopicOrPartition}
+	}
+
+	recs := make([]Record, 0, len(req.Records))
+	for _, rj := range req.Records {
+		kb, _ := tryB64(rj.Key)
+		vb, _ := tryB64(rj.Value)
+		recs = append(recs, Record{
+			Key:   kb,
+			Value: vb,
+			Ts:    rj.Ts,
+		})
+	}
+
+	base := topic.Partitions[part].appendRecs(recs)
+	_, hw := topic.Partitions[part].fetch(0, 0)
+
+	return &ProduceResponse{
+		Topic:         req.Topic,
+		Partition:     part,
+		BaseOffset:    base,
+		NumRecords:    len(recs),
+		HighWatermark: hw,
+	}, nil
+}
+
+func (b *Broker) handleFetch(req FetchRequest) (*FetchResponse, *brokerErr) {
+	if req.Topic == "" || req.Partition < 0 {
+		return nil, &brokerErr{ErrInvalidRequest}
+	}
+	topic, ok := b.getTopic(req.Topic)
+	if !ok || req.Partition >= len(topic.Partitions) {
+		return nil, &brokerErr{ErrUnknownTopicOrPartition}
+	}
+
+	recs, hw := topic.Partitions[req.Partition].fetch(req.Offset, 0)
+	out := make([]FetchedRecord, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, FetchedRecord{
+			Offset: r.Offset,
+			Key:    base64.StdEncoding.EncodeToString(r.Key),
+			Value:  base64.StdEncoding.EncodeToString(r.Value),
+			Ts:     r.Ts,
+		})
+	}
+	return &FetchResponse{Records: out, HighWatermark: hw}, nil
+}
+
+func (b *Broker) handleCommit(req CommitRequest) (*CommitResponse, *brokerErr) {
+	if req.Topic == "" || req.Partition < 0 || req.Group == "" || req.Offset < 0 {
+		return nil, &brokerErr{ErrInvalidRequest}
+	}
+	if _, ok := b.getTopic(req.Topic); !ok {
+		return nil, &brokerErr{ErrUnknownTopicOrPartition}
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.offsets[req.Group]; !ok {
+		b.offsets[req.Group] = make(map[string]map[int]int64)
+	}
+	if _, ok := b.offsets[req.Group][req.Topic]; !ok {
+		b.offsets[req.Group][req.Topic] = make(map[int]int64)
+	}
+	// Idempotent: always set "next offset to read"
+	b.offsets[req.Group][req.Topic][req.Partition] = req.Offset
+	return &CommitResponse{OK: true}, nil
+}
+
+// ===========================
+// Helpers
+// ===========================
+
+func (b *Broker) getTopic(name string) (*Topic, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	t, ok := b.topics[name]
+	return t, ok
+}
+
+func tryB64(s string) ([]byte, error) {
+	if s == "" {
+		return nil, nil
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		// If it's not valid base64, treat as raw bytes (dev-friendly)
+		return []byte(s), nil
+	}
+	return b, nil
+}
+
+func writeJSON(conn net.Conn, typ uint8, v any) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		writeError(conn, typ, ErrInternalIO, err)
+		return
+	}
+	_ = proto.WriteFrame(conn, typ, body)
+}
+
+func writeError(conn net.Conn, typ uint8, code string, cause error) {
+	errorsTotal.WithLabelValues(code).Inc()
+	var er ErrorResponse
+	er.Error.Code = code
+	if cause != nil {
+		er.Error.Message = cause.Error()
+	} else {
+		er.Error.Message = code
+	}
+	body, _ := json.Marshal(er)
+	_ = proto.WriteFrame(conn, typ, body)
 }

--- a/internal/broker/handlers_test.go
+++ b/internal/broker/handlers_test.go
@@ -1,0 +1,62 @@
+package broker
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func b64(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+func TestCreateProduceFetchCommitHappyPath(t *testing.T) {
+	br := New()
+
+	// Create topic with 2 partitions
+	if _, be := br.handleCreateTopic(CreateTopicRequest{Topic: "user-events", Partitions: 2}); be != nil {
+		t.Fatalf("create topic: %v", be)
+	}
+
+	// Produce two records using partition = -1 (hash by key)
+	presp, be := br.handleProduce(ProduceRequest{
+		Topic:     "user-events",
+		Partition: -1,
+		Records: []RecordJSON{
+			{Key: b64("user1"), Value: b64(`{"a":1}`), Ts: 1},
+			{Key: b64("user2"), Value: b64(`{"a":2}`), Ts: 2},
+		},
+	})
+	if be != nil {
+		t.Fatalf("produce: %v", be)
+	}
+	if presp.NumRecords != 2 {
+		t.Fatalf("expected 2 appended, got %d", presp.NumRecords)
+	}
+
+	// Since routing is by key hash, records could land in different partitions.
+	// Fetch both partitions from 0 and sum up.
+	var total int
+	for p := 0; p < 2; p++ {
+		fresp, be := br.handleFetch(FetchRequest{
+			Topic:     "user-events",
+			Partition: p,
+			Offset:    0,
+		})
+		if be != nil {
+			t.Fatalf("fetch p=%d: %v", p, be)
+		}
+		total += len(fresp.Records)
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 total fetched, got %d", total)
+	}
+
+	// Commit next offset for group
+	cresp, be := br.handleCommit(CommitRequest{
+		Topic:     "user-events",
+		Partition: 0,
+		Group:     "analytics",
+		Offset:    10,
+	})
+	if be != nil || !cresp.OK {
+		t.Fatalf("commit failed: %v", be)
+	}
+}

--- a/internal/proto/frame_test.go
+++ b/internal/proto/frame_test.go
@@ -1,0 +1,25 @@
+package proto
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	payload := []byte(`{"hello":"world"}`)
+
+	if err := WriteFrame(&buf, TypeProduce, payload); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	fr, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if fr.Type != TypeProduce {
+		t.Fatalf("type mismatch: got %d", fr.Type)
+	}
+	if string(fr.Payload) != string(payload) {
+		t.Fatalf("payload mismatch: got=%s want=%s", fr.Payload, payload)
+	}
+}


### PR DESCRIPTION
This pull request adds initial Grafana monitoring support and new tests for core broker and protocol functionality. The most significant changes include provisioning Grafana with Prometheus data source and dashboards, as well as introducing tests for broker handlers and protocol frame round-trips.

**Grafana Monitoring Integration:**

* Added persistent volumes for Grafana in `compose.yaml` to enable provisioning and dashboard storage.
* Created a Prometheus data source configuration for Grafana at `deploy/grafana/provisioning/datasources/prometheus.yml`.
* Added a dashboard provider configuration in `deploy/grafana/provisioning/dashboards/cafelog.yml` to automatically load dashboards.
* Introduced a new overview dashboard at `deploy/grafana/dashboards/cafelog-overview.json` showing request rates and active TCP connections.

**Testing Enhancements:**

* Added a comprehensive broker handler test covering topic creation, record production, fetching, and committing in `internal/broker/handlers_test.go`.
* Added protocol frame round-trip serialization/deserialization test in `internal/proto/frame_test.go`.